### PR TITLE
Correct cosim_execution_step return type

### DIFF
--- a/src/libcosimpy/CosimExecution.py
+++ b/src/libcosimpy/CosimExecution.py
@@ -60,7 +60,7 @@ class CosimExecution(Structure):
             lib=CosimLibrary.lib,
             funcname="cosim_execution_step",
             argtypes=[POINTER(CosimExecution), c_int64],
-            restype=None,
+            restype=c_int,
         )
         self.__add_local_slave = wrap_function(
             lib=CosimLibrary.lib,


### PR DESCRIPTION
Corrects the return type from libcosimc function `cosim_executioin_step` so that the success/failure of a step can be checked.