### PR TITLE
Build fix

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -56,6 +56,11 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+      - name: Setup MSBuild 2022
+        uses: microsoft/setup-msbuild@v3
+        with:
+          vs-version: '2022'
+        if: runner.os == 'Windows'
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.4.1
         env:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup MSBuild 2022
         uses: microsoft/setup-msbuild@v3
         with:
-          vs-version: '2022'
+          vs-version: '17.0'
         if: runner.os == 'Windows'
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.4.1

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -56,6 +56,10 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+      - uses: ssciwr/doxygen-install@v2 # Currently libcosimc build fails without doxygen installed
+        with:
+          version: "1.16.1"
+        if: runner.os == 'Windows'
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.4.1
         env:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ 'windows-latest', 'ubuntu-latest' ]
+        platform: [ 'windows-2022', 'ubuntu-latest' ] # windows-2022 because fmilibrary uses older cmake that does not support msbuild 18
         python-version: [ 'cp311', 'cp312', 'cp313', 'cp314' ]
     timeout-minutes: 45
     env:
@@ -56,11 +56,6 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-      - name: Setup MSBuild 2022
-        uses: microsoft/setup-msbuild@v3
-        with:
-          vs-version: '17.0'
-        if: runner.os == 'Windows'
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.4.1
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,6 @@ dependencies = [
 build = "*-manylinux_x86_64 *-win_amd64"
 build-frontend = "build[uv]"
 test-command = "uv run --with pytest pytest {package}"
-before-all = [
-    "pip install cmake~=4.3.0"
-]
 
 [tool.cibuildwheel.linux]
 before-all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ dependencies = [
 build = "*-manylinux_x86_64 *-win_amd64"
 build-frontend = "build[uv]"
 test-command = "uv run --with pytest pytest {package}"
+before-all = [
+    "pip install cmake~=4.3.0"
+]
 
 [tool.cibuildwheel.linux]
 before-all = [


### PR DESCRIPTION
- Building on windows-2022 due to fmilibrary currently cannot be built on newer visual studio version (older cmake)
- Installing doxygen on windows so that libcosimc builds successfully.